### PR TITLE
feat: remove a TODO comment

### DIFF
--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -134,8 +134,6 @@ contract Oracle is IOracle {
       revert Oracle_AlreadyFinalized(_response.requestId);
     }
 
-    // TODO: Allow multiple disputes per response to prevent an attacker from starting and losing a dispute,
-    // making it impossible for non-malicious actors to dispute a response?
     if (disputeOf[_dispute.responseId] != bytes32(0)) {
       revert Oracle_ResponseAlreadyDisputed(_dispute.responseId);
     }


### PR DESCRIPTION
The rationale for not implementing multiple disputes per response:
- the described attack can be mitigated by using certain modules, e.g. pre-dispute modules computing the correct answer on-chain
- anyone seeing the attack can participate in the dispute or escalate it, making it less attractive for the attacker
