### PR TITLE
refactor: use block.timestamp instead of block.number

### DIFF
--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -134,7 +134,7 @@ contract Oracle is IOracle {
     _responseIds[_requestId] = abi.encodePacked(_responseIds[_requestId], _responseId);
     responseCreatedAt[_responseId] = uint128(block.timestamp);
 
-    emit ResponseProposed(_requestId, _responseId, _response, block.number);
+    emit ResponseProposed(_requestId, _responseId, _response);
   }
 
   /// @inheritdoc IOracle
@@ -175,7 +175,7 @@ contract Oracle is IOracle {
 
     IDisputeModule(_request.disputeModule).disputeResponse(_request, _response, _dispute);
 
-    emit ResponseDisputed(_responseId, _disputeId, _dispute, block.number);
+    emit ResponseDisputed(_responseId, _disputeId, _dispute);
   }
 
   /// @inheritdoc IOracle
@@ -200,7 +200,7 @@ contract Oracle is IOracle {
     // Notify the dispute module about the escalation
     IDisputeModule(_request.disputeModule).onDisputeStatusChange(_disputeId, _request, _response, _dispute);
 
-    emit DisputeEscalated(msg.sender, _disputeId, block.number);
+    emit DisputeEscalated(msg.sender, _disputeId);
 
     if (address(_request.resolutionModule) != address(0)) {
       // Initiate the resolution
@@ -232,7 +232,7 @@ contract Oracle is IOracle {
 
     IResolutionModule(_request.resolutionModule).resolveDispute(_disputeId, _request, _response, _dispute);
 
-    emit DisputeResolved(_disputeId, _dispute, msg.sender, block.number);
+    emit DisputeResolved(_disputeId, _dispute, msg.sender);
   }
 
   /// @inheritdoc IOracle
@@ -258,7 +258,7 @@ contract Oracle is IOracle {
     disputeStatus[_disputeId] = _status;
     IDisputeModule(_request.disputeModule).onDisputeStatusChange(_disputeId, _request, _response, _dispute);
 
-    emit DisputeStatusUpdated(_disputeId, _dispute, _status, block.number);
+    emit DisputeStatusUpdated(_disputeId, _dispute, _status);
   }
 
   /**
@@ -346,7 +346,7 @@ contract Oracle is IOracle {
     IResponseModule(_request.responseModule).finalizeRequest(_request, _response, msg.sender);
     IRequestModule(_request.requestModule).finalizeRequest(_request, _response, msg.sender);
 
-    emit OracleRequestFinalized(_requestId, _responseId, msg.sender, block.number);
+    emit OracleRequestFinalized(_requestId, _responseId, msg.sender);
   }
 
   /**
@@ -444,6 +444,6 @@ contract Oracle is IOracle {
     _participants[_requestId] = abi.encodePacked(_participants[_requestId], msg.sender);
     IRequestModule(_request.requestModule).createRequest(_requestId, _request.requestModuleData, msg.sender);
 
-    emit RequestCreated(_requestId, _request, _ipfsHash, block.number);
+    emit RequestCreated(_requestId, _request, _ipfsHash);
   }
 }

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -132,7 +132,7 @@ contract Oracle is IOracle {
     _participants[_requestId] = abi.encodePacked(_participants[_requestId], _response.proposer);
     IResponseModule(_request.responseModule).propose(_request, _response, msg.sender);
     _responseIds[_requestId] = abi.encodePacked(_responseIds[_requestId], _responseId);
-    responseCreatedAt[_responseId] = uint128(block.number);
+    responseCreatedAt[_responseId] = uint128(block.timestamp);
 
     emit ResponseProposed(_requestId, _responseId, _response, block.number);
   }
@@ -171,7 +171,7 @@ contract Oracle is IOracle {
     _participants[_requestId] = abi.encodePacked(_participants[_requestId], msg.sender);
     disputeStatus[_disputeId] = DisputeStatus.Active;
     disputeOf[_responseId] = _disputeId;
-    disputeCreatedAt[_disputeId] = uint128(block.number);
+    disputeCreatedAt[_disputeId] = uint128(block.timestamp);
 
     IDisputeModule(_request.disputeModule).disputeResponse(_request, _response, _dispute);
 
@@ -332,7 +332,7 @@ contract Oracle is IOracle {
       revert Oracle_AlreadyFinalized(_requestId);
     }
 
-    finalizedAt[_requestId] = uint128(block.number);
+    finalizedAt[_requestId] = uint128(block.timestamp);
 
     if (address(_request.finalityModule) != address(0)) {
       IFinalityModule(_request.finalityModule).finalizeRequest(_request, _response, msg.sender);
@@ -430,7 +430,7 @@ contract Oracle is IOracle {
 
     _requestId = ValidatorLib._getId(_request);
     nonceToRequestId[_requestNonce] = _requestId;
-    requestCreatedAt[_requestId] = uint128(block.number);
+    requestCreatedAt[_requestId] = uint128(block.timestamp);
 
     // solhint-disable-next-line func-named-parameters
     _allowedModules[_requestId] = abi.encodePacked(

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -15,16 +15,16 @@ contract Oracle is IOracle {
   using ValidatorLib for *;
 
   /// @inheritdoc IOracle
-  mapping(bytes32 _requestId => uint128 _finalizedAt) public finalizedAt;
+  mapping(bytes32 _requestId => uint256 _finalizedAt) public finalizedAt;
 
   /// @inheritdoc IOracle
-  mapping(bytes32 _id => uint128 _requestCreatedAt) public requestCreatedAt;
+  mapping(bytes32 _id => uint256 _requestCreatedAt) public requestCreatedAt;
 
   /// @inheritdoc IOracle
-  mapping(bytes32 _id => uint128 _responseCreatedAt) public responseCreatedAt;
+  mapping(bytes32 _id => uint256 _responseCreatedAt) public responseCreatedAt;
 
   /// @inheritdoc IOracle
-  mapping(bytes32 _id => uint128 _disputeCreatedAt) public disputeCreatedAt;
+  mapping(bytes32 _id => uint256 _disputeCreatedAt) public disputeCreatedAt;
 
   /// @inheritdoc IOracle
   mapping(bytes32 _responseId => bytes32 _disputeId) public disputeOf;
@@ -132,7 +132,7 @@ contract Oracle is IOracle {
     _participants[_requestId] = abi.encodePacked(_participants[_requestId], _response.proposer);
     IResponseModule(_request.responseModule).propose(_request, _response, msg.sender);
     _responseIds[_requestId] = abi.encodePacked(_responseIds[_requestId], _responseId);
-    responseCreatedAt[_responseId] = uint128(block.timestamp);
+    responseCreatedAt[_responseId] = block.timestamp;
 
     emit ResponseProposed(_requestId, _responseId, _response);
   }
@@ -171,7 +171,7 @@ contract Oracle is IOracle {
     _participants[_requestId] = abi.encodePacked(_participants[_requestId], msg.sender);
     disputeStatus[_disputeId] = DisputeStatus.Active;
     disputeOf[_responseId] = _disputeId;
-    disputeCreatedAt[_disputeId] = uint128(block.timestamp);
+    disputeCreatedAt[_disputeId] = block.timestamp;
 
     IDisputeModule(_request.disputeModule).disputeResponse(_request, _response, _dispute);
 
@@ -332,7 +332,7 @@ contract Oracle is IOracle {
       revert Oracle_AlreadyFinalized(_requestId);
     }
 
-    finalizedAt[_requestId] = uint128(block.timestamp);
+    finalizedAt[_requestId] = block.timestamp;
 
     if (address(_request.finalityModule) != address(0)) {
       IFinalityModule(_request.finalityModule).finalizeRequest(_request, _response, msg.sender);
@@ -430,7 +430,7 @@ contract Oracle is IOracle {
 
     _requestId = ValidatorLib._getId(_request);
     nonceToRequestId[_requestNonce] = _requestId;
-    requestCreatedAt[_requestId] = uint128(block.timestamp);
+    requestCreatedAt[_requestId] = block.timestamp;
 
     // solhint-disable-next-line func-named-parameters
     _allowedModules[_requestId] = abi.encodePacked(

--- a/solidity/interfaces/IOracle.sol
+++ b/solidity/interfaces/IOracle.sol
@@ -301,34 +301,34 @@ interface IOracle {
   function finalizedResponseId(bytes32 _requestId) external view returns (bytes32 _finalizedResponseId);
 
   /**
-   * @notice The number of the block at which a request was created
+   * @notice The block's timestamp at which a request was created
    *
    * @param _id The request id
-   * @return _requestCreatedAt The block number
+   * @return _requestCreatedAt The block's timestamp
    */
   function requestCreatedAt(bytes32 _id) external view returns (uint128 _requestCreatedAt);
 
   /**
-   * @notice The number of the block at which a response was created
+   * @notice The block's timestamp at which a response was created
    *
    * @param _id The response id
-   * @return _responseCreatedAt The block number
+   * @return _responseCreatedAt The block's timestamp
    */
   function responseCreatedAt(bytes32 _id) external view returns (uint128 _responseCreatedAt);
 
   /**
-   * @notice The number of the block at which a dispute was created
+   * @notice The block's timestamp at which a dispute was created
    *
    * @param _id The dispute id
-   * @return _disputeCreatedAt The block number
+   * @return _disputeCreatedAt The block's timestamp
    */
   function disputeCreatedAt(bytes32 _id) external view returns (uint128 _disputeCreatedAt);
 
   /**
-   * @notice The number of the block at which a request was finalized
+   * @notice The block's timestamp at which a request was finalized
    *
    * @param _requestId The request id
-   * @return _finalizedAt The block number
+   * @return _finalizedAt The block's timestamp
    */
   function finalizedAt(bytes32 _requestId) external view returns (uint128 _finalizedAt);
 

--- a/solidity/interfaces/IOracle.sol
+++ b/solidity/interfaces/IOracle.sol
@@ -15,68 +15,55 @@ interface IOracle {
    * @param _requestId The id of the created request
    * @param _request The request that has been created
    * @param _ipfsHash The hashed IPFS CID of the metadata json
-   * @param _blockNumber The current block number
    */
-  event RequestCreated(bytes32 indexed _requestId, Request _request, bytes32 _ipfsHash, uint256 _blockNumber);
+  event RequestCreated(bytes32 indexed _requestId, Request _request, bytes32 _ipfsHash);
 
   /**
    * @notice Emitted when a response is proposed
    * @param _requestId The id of the request
    * @param _responseId The id of the proposed response
    * @param _response The response that has been proposed
-   * @param _blockNumber The current block number
    */
-  event ResponseProposed(
-    bytes32 indexed _requestId, bytes32 indexed _responseId, Response _response, uint256 _blockNumber
-  );
+  event ResponseProposed(bytes32 indexed _requestId, bytes32 indexed _responseId, Response _response);
 
   /**
    * @notice Emitted when a response is disputed
    * @param _responseId The id of the response being disputed
    * @param _disputeId The id of the dispute
    * @param _dispute The dispute that has been created
-   * @param _blockNumber The current block number
    */
-  event ResponseDisputed(
-    bytes32 indexed _responseId, bytes32 indexed _disputeId, Dispute _dispute, uint256 _blockNumber
-  );
+  event ResponseDisputed(bytes32 indexed _responseId, bytes32 indexed _disputeId, Dispute _dispute);
 
   /**
    * @notice Emitted when a request is finalized
    * @param _requestId The id of the request being finalized
    * @param _responseId The id of the final response, may be empty
    * @param _caller The address of the user who finalized the request
-   * @param _blockNumber The current block number
    */
-  event OracleRequestFinalized(
-    bytes32 indexed _requestId, bytes32 indexed _responseId, address indexed _caller, uint256 _blockNumber
-  );
+  event OracleRequestFinalized(bytes32 indexed _requestId, bytes32 indexed _responseId, address indexed _caller);
 
   /**
    * @notice Emitted when a dispute is escalated
    * @param _caller The address of the user who escalated the dispute
    * @param _disputeId The id of the dispute being escalated
-   * @param _blockNumber The block number of the escalation
    */
-  event DisputeEscalated(address indexed _caller, bytes32 indexed _disputeId, uint256 _blockNumber);
+  event DisputeEscalated(address indexed _caller, bytes32 indexed _disputeId);
 
   /**
    * @notice Emitted when a dispute's status changes
    * @param _disputeId The id of the dispute
    * @param _dispute The dispute that is being updated
    * @param _status The new dispute status
-   * @param _blockNumber The block number of the status update
    */
-  event DisputeStatusUpdated(bytes32 indexed _disputeId, Dispute _dispute, DisputeStatus _status, uint256 _blockNumber);
+  event DisputeStatusUpdated(bytes32 indexed _disputeId, Dispute _dispute, DisputeStatus _status);
 
   /**
    * @notice Emitted when a dispute is resolved
    * @param _disputeId The id of the dispute being resolved
    * @param _dispute The dispute that is being updated
    * @param _caller The address of the user who resolved the dispute
-   * @param _blockNumber The block number of the dispute resolution
    */
-  event DisputeResolved(bytes32 indexed _disputeId, Dispute _dispute, address indexed _caller, uint256 _blockNumber);
+  event DisputeResolved(bytes32 indexed _disputeId, Dispute _dispute, address indexed _caller);
 
   /*///////////////////////////////////////////////////////////////
                               ERRORS

--- a/solidity/interfaces/IOracle.sol
+++ b/solidity/interfaces/IOracle.sol
@@ -293,7 +293,7 @@ interface IOracle {
    * @param _id The request id
    * @return _requestCreatedAt The block's timestamp
    */
-  function requestCreatedAt(bytes32 _id) external view returns (uint128 _requestCreatedAt);
+  function requestCreatedAt(bytes32 _id) external view returns (uint256 _requestCreatedAt);
 
   /**
    * @notice The block's timestamp at which a response was created
@@ -301,7 +301,7 @@ interface IOracle {
    * @param _id The response id
    * @return _responseCreatedAt The block's timestamp
    */
-  function responseCreatedAt(bytes32 _id) external view returns (uint128 _responseCreatedAt);
+  function responseCreatedAt(bytes32 _id) external view returns (uint256 _responseCreatedAt);
 
   /**
    * @notice The block's timestamp at which a dispute was created
@@ -309,7 +309,7 @@ interface IOracle {
    * @param _id The dispute id
    * @return _disputeCreatedAt The block's timestamp
    */
-  function disputeCreatedAt(bytes32 _id) external view returns (uint128 _disputeCreatedAt);
+  function disputeCreatedAt(bytes32 _id) external view returns (uint256 _disputeCreatedAt);
 
   /**
    * @notice The block's timestamp at which a request was finalized
@@ -317,7 +317,7 @@ interface IOracle {
    * @param _requestId The request id
    * @return _finalizedAt The block's timestamp
    */
-  function finalizedAt(bytes32 _requestId) external view returns (uint128 _finalizedAt);
+  function finalizedAt(bytes32 _requestId) external view returns (uint256 _finalizedAt);
 
   /*///////////////////////////////////////////////////////////////
                               LOGIC

--- a/solidity/interfaces/modules/dispute/IDisputeModule.sol
+++ b/solidity/interfaces/modules/dispute/IDisputeModule.sol
@@ -14,14 +14,9 @@ interface IDisputeModule is IModule {
    * @param _responseId The id of the response disputed
    * @param _disputeId The id of the dispute
    * @param _dispute The dispute that is being created
-   * @param _blockNumber The current block number
    */
   event ResponseDisputed(
-    bytes32 indexed _requestId,
-    bytes32 indexed _responseId,
-    bytes32 indexed _disputeId,
-    IOracle.Dispute _dispute,
-    uint256 _blockNumber
+    bytes32 indexed _requestId, bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute
   );
 
   /**

--- a/solidity/test/unit/Oracle.t.sol
+++ b/solidity/test/unit/Oracle.t.sol
@@ -174,7 +174,7 @@ contract Oracle_Unit_CreateRequest is BaseTest {
     assertTrue(oracle.isParticipant(_requestId, requester));
 
     // Check: Saves the number of the block
-    assertEq(oracle.requestCreatedAt(_requestId), block.number);
+    assertEq(oracle.requestCreatedAt(_requestId), block.timestamp);
 
     // Check: Sets allowedModules
     assertTrue(oracle.allowedModule(_requestId, address(requestModule)));
@@ -275,7 +275,7 @@ contract Oracle_Unit_CreateRequests is BaseTest {
       assertTrue(oracle.isParticipant(_requestsIds[_i], requester));
 
       // Check: Saves the number of the block
-      assertEq(oracle.requestCreatedAt(_requestsIds[_i]), block.number);
+      assertEq(oracle.requestCreatedAt(_requestsIds[_i]), block.timestamp);
 
       // Check: Sets allowedModules
       assertTrue(oracle.allowedModule(_requestsIds[_i], address(requestModule)));
@@ -424,7 +424,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     // Set the request creation time
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
 
     // Mock and expect the responseModule propose call:
     _mockAndExpect(
@@ -478,7 +478,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
   function test_proposeResponse_revertsIfInvalidCaller(address _caller) public {
     vm.assume(_caller != proposer && _caller != address(disputeModule));
 
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(IOracle.Oracle_InvalidProposer.selector);
@@ -493,7 +493,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
    */
   function test_proposeResponse_revertsIfDuplicateResponse() public {
     // Set the request creation time
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
 
     // Test: propose a response
     vm.prank(proposer);
@@ -516,7 +516,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
     // Set the finalization time
     bytes32 _requestId = _getId(mockRequest);
     oracle.mock_setFinalizedAt(_requestId, _finalizedAt);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
 
     // Check: Reverts if already finalized?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, (_requestId)));
@@ -535,7 +535,7 @@ contract Oracle_Unit_DisputeResponse is BaseTest {
     _responseId = _getId(mockResponse);
     _disputeId = _getId(mockDispute);
 
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
   }
 
   /**
@@ -573,7 +573,7 @@ contract Oracle_Unit_DisputeResponse is BaseTest {
    */
   function test_disputeResponse_revertIfProposerIsNotValid(address _otherProposer) public {
     vm.assume(_otherProposer != proposer);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(IOracle.Oracle_InvalidProposer.selector);
@@ -634,7 +634,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
    */
   function test_updateDisputeStatus() public {
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.number));
+    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.timestamp));
 
     // Try every initial status
     for (uint256 _previousStatus; _previousStatus < uint256(type(IOracle.DisputeStatus).max); _previousStatus++) {
@@ -679,7 +679,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
 
     // Setting a random dispute id, not matching the mockDispute
     oracle.mock_setDisputeOf(_getId(mockResponse), _randomId);
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _disputeId));
@@ -701,7 +701,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
 
     // Mock the dispute
     oracle.mock_setDisputeOf(_responseId, _disputeId);
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_NotDisputeOrResolutionModule.selector, proposer));
@@ -735,9 +735,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
   function test_resolveDispute_callsResolutionModule() public {
     // Mock the dispute
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
@@ -761,7 +761,7 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
    * @notice Test the revert when the function is called with an non-existent dispute id
    */
   function test_resolveDispute_revertsIfInvalidDisputeId() public {
-    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.number));
+    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _getId(mockDispute)));
@@ -798,9 +798,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
 
       // Mock the dispute
       oracle.mock_setDisputeOf(_responseId, _disputeId);
-      oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-      oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
-      oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+      oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+      oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+      oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
       oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus(_status));
 
       // Check: revert?
@@ -829,9 +829,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
     // Mock the dispute
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Escalated);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_NoResolutionModule.selector, _disputeId));
@@ -913,8 +913,8 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
 
     // Mock the finalize call on all modules
     bytes memory _calldata = abi.encodeCall(IModule.finalizeRequest, (mockRequest, mockResponse, _caller));
@@ -936,7 +936,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     vm.prank(_caller);
     oracle.finalize(mockRequest, mockResponse);
 
-    assertEq(oracle.finalizedAt(_requestId), block.number);
+    assertEq(oracle.finalizedAt(_requestId), block.timestamp);
   }
 
   /**
@@ -955,7 +955,7 @@ contract Oracle_Unit_Finalize is BaseTest {
    */
   function test_finalize_revertsIfInvalidResponse() public {
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
     oracle.mock_setResponseCreatedAt(_requestId, 0);
 
     // Check: revert?
@@ -974,10 +974,10 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     // Test: finalize a finalized request
-    oracle.mock_setFinalizedAt(_requestId, uint128(block.number));
+    oracle.mock_setFinalizedAt(_requestId, uint128(block.timestamp));
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
 
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, _requestId));
     vm.prank(requester);
@@ -995,8 +995,8 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Store the response
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_requestId, uint128(block.timestamp));
 
     // Test: finalize the request
     vm.expectRevert(ValidatorLib.ValidatorLib_InvalidResponseBody.selector);
@@ -1018,8 +1018,8 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Submit a response to the request
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
     oracle.mock_setDisputeOf(_responseId, _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Won);
 
@@ -1042,7 +1042,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     vm.assume(_caller != address(0));
 
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
     mockResponse.requestId = bytes32(0);
 
     // Create mock request and store it
@@ -1084,7 +1084,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     vm.assume(_status <= uint256(type(IOracle.DisputeStatus).max));
 
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
 
     IOracle.DisputeStatus _disputeStatus = IOracle.DisputeStatus(_status);
 
@@ -1121,8 +1121,8 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _requestId = _getId(mockRequest);
 
     // Override the finalizedAt to make it be finalized
-    oracle.mock_setFinalizedAt(_requestId, uint128(block.number));
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
+    oracle.mock_setFinalizedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
 
     // Test: finalize a finalized request
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, _requestId));
@@ -1140,7 +1140,7 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Submit a response to the request
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
 
     // Check: reverts?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_FinalizableResponseExists.selector, _responseId));
@@ -1160,9 +1160,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     // Mock and expect the dispute module call
     _mockAndExpect(
@@ -1206,9 +1206,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
 
     // Mock and expect the dispute module call
     _mockAndExpect(
@@ -1234,8 +1234,8 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
    */
   function test_escalateDispute_revertsIfInvalidDispute() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
     oracle.mock_setDisputeCreatedAt(_disputeId, 0);
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDispute.selector));
 
@@ -1247,9 +1247,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
    */
   function test_escalateDispute_revertsIfDisputeNotValid() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _disputeId));
 
     // Test: escalate the dispute
@@ -1258,9 +1258,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
   function test_escalateDispute_revertsIfDisputeNotActive() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.number));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.number));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.number));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
 
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_CannotEscalate.selector, _disputeId));

--- a/solidity/test/unit/Oracle.t.sol
+++ b/solidity/test/unit/Oracle.t.sol
@@ -91,23 +91,13 @@ contract BaseTest is Test, Helpers {
   bytes32 internal _ipfsHash = bytes32('QmR4uiJH654k3Ta2uLLQ8r');
 
   // Events
-  event RequestCreated(bytes32 indexed _requestId, IOracle.Request _request, bytes32 _ipfsHash, uint256 _blockNumber);
-  event ResponseProposed(
-    bytes32 indexed _requestId, bytes32 indexed _responseId, IOracle.Response _response, uint256 _blockNumber
-  );
-  event ResponseDisputed(
-    bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute, uint256 _blockNumber
-  );
-  event OracleRequestFinalized(
-    bytes32 indexed _requestId, bytes32 indexed _responseId, address indexed _caller, uint256 _blockNumber
-  );
-  event DisputeEscalated(address indexed _caller, bytes32 indexed _disputeId, uint256 _blockNumber);
-  event DisputeStatusUpdated(
-    bytes32 indexed _disputeId, IOracle.Dispute _dispute, IOracle.DisputeStatus _status, uint256 _blockNumber
-  );
-  event DisputeResolved(
-    bytes32 indexed _disputeId, IOracle.Dispute _dispute, address indexed _caller, uint256 _blockNumber
-  );
+  event RequestCreated(bytes32 indexed _requestId, IOracle.Request _request, bytes32 _ipfsHash);
+  event ResponseProposed(bytes32 indexed _requestId, bytes32 indexed _responseId, IOracle.Response _response);
+  event ResponseDisputed(bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute);
+  event OracleRequestFinalized(bytes32 indexed _requestId, bytes32 indexed _responseId, address indexed _caller);
+  event DisputeEscalated(address indexed _caller, bytes32 indexed _disputeId);
+  event DisputeStatusUpdated(bytes32 indexed _disputeId, IOracle.Dispute _dispute, IOracle.DisputeStatus _status);
+  event DisputeResolved(bytes32 indexed _disputeId, IOracle.Dispute _dispute, address indexed _caller);
 
   function setUp() public virtual {
     oracle = new MockOracle();
@@ -164,7 +154,7 @@ contract Oracle_Unit_CreateRequest is BaseTest {
 
     // Check: emits RequestCreated event?
     _expectEmit(address(oracle));
-    emit RequestCreated(_getId(mockRequest), mockRequest, _ipfsHash, block.number);
+    emit RequestCreated(_getId(mockRequest), mockRequest, _ipfsHash);
 
     // Test: create the request
     vm.prank(requester);
@@ -262,7 +252,7 @@ contract Oracle_Unit_CreateRequests is BaseTest {
 
       // Check: emits RequestCreated event?
       _expectEmit(address(oracle));
-      emit RequestCreated(_theoreticalRequestId, mockRequest, _ipfsHashes[_i], block.number);
+      emit RequestCreated(_theoreticalRequestId, mockRequest, _ipfsHashes[_i]);
     }
 
     vm.prank(requester);
@@ -435,7 +425,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
 
     // Check: emits ResponseProposed event?
     _expectEmit(address(oracle));
-    emit ResponseProposed(_requestId, _responseId, mockResponse, block.number);
+    emit ResponseProposed(_requestId, _responseId, mockResponse);
 
     // Test: propose the response
     vm.prank(proposer);
@@ -445,7 +435,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
 
     // Check: emits ResponseProposed event?
     _expectEmit(address(oracle));
-    emit ResponseProposed(_requestId, _getId(mockResponse), mockResponse, block.number);
+    emit ResponseProposed(_requestId, _getId(mockResponse), mockResponse);
 
     vm.prank(proposer);
     bytes32 _secondResponseId = oracle.proposeResponse(mockRequest, mockResponse);
@@ -558,7 +548,7 @@ contract Oracle_Unit_DisputeResponse is BaseTest {
 
       // Check: emits ResponseDisputed event?
       _expectEmit(address(oracle));
-      emit ResponseDisputed(_responseId, _disputeId, mockDispute, block.number);
+      emit ResponseDisputed(_responseId, _disputeId, mockDispute);
 
       vm.prank(disputer);
       oracle.disputeResponse(mockRequest, mockResponse, mockDispute);
@@ -656,7 +646,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
 
         // Check: emits DisputeStatusUpdated event?
         _expectEmit(address(oracle));
-        emit DisputeStatusUpdated(_disputeId, mockDispute, IOracle.DisputeStatus(_newStatus), block.number);
+        emit DisputeStatusUpdated(_disputeId, mockDispute, IOracle.DisputeStatus(_newStatus));
 
         // Test: change the status
         vm.prank(address(resolutionModule));
@@ -751,7 +741,7 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
 
     // Check: emits DisputeResolved event?
     _expectEmit(address(oracle));
-    emit DisputeResolved(_disputeId, mockDispute, address(this), block.number);
+    emit DisputeResolved(_disputeId, mockDispute, address(this));
 
     // Test: resolve the dispute
     oracle.resolveDispute(mockRequest, mockResponse, mockDispute);
@@ -930,7 +920,7 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Check: emits OracleRequestFinalized event?
     _expectEmit(address(oracle));
-    emit OracleRequestFinalized(_requestId, _responseId, _caller, block.number);
+    emit OracleRequestFinalized(_requestId, _responseId, _caller);
 
     // Test: finalize the request
     vm.prank(_caller);
@@ -1059,7 +1049,7 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Check: emits OracleRequestFinalized event?
     _expectEmit(address(oracle));
-    emit OracleRequestFinalized(_requestId, bytes32(0), _caller, block.number);
+    emit OracleRequestFinalized(_requestId, bytes32(0), _caller);
 
     // Test: finalize the request
     vm.prank(_caller);
@@ -1107,7 +1097,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     // The finalization should come through
     // Check: emits OracleRequestFinalized event?
     _expectEmit(address(oracle));
-    emit OracleRequestFinalized(_requestId, bytes32(0), _caller, block.number);
+    emit OracleRequestFinalized(_requestId, bytes32(0), _caller);
 
     // Test: finalize the request
     vm.prank(_caller);
@@ -1180,7 +1170,7 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     // Expect dispute escalated event
     _expectEmit(address(oracle));
-    emit DisputeEscalated(address(this), _disputeId, block.number);
+    emit DisputeEscalated(address(this), _disputeId);
 
     // Test: escalate the dispute
     oracle.escalateDispute(mockRequest, mockResponse, mockDispute);
@@ -1219,7 +1209,7 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     // Expect dispute escalated event
     _expectEmit(address(oracle));
-    emit DisputeEscalated(address(this), _disputeId, block.number);
+    emit DisputeEscalated(address(this), _disputeId);
 
     // Test: escalate the dispute
     oracle.escalateDispute(mockRequest, mockResponse, mockDispute);

--- a/solidity/test/unit/Oracle.t.sol
+++ b/solidity/test/unit/Oracle.t.sol
@@ -36,7 +36,7 @@ contract MockOracle is Oracle {
     finalizedResponseId[_requestId] = _finalizedResponseId;
   }
 
-  function mock_setFinalizedAt(bytes32 _requestId, uint128 _finalizedAt) external {
+  function mock_setFinalizedAt(bytes32 _requestId, uint256 _finalizedAt) external {
     finalizedAt[_requestId] = _finalizedAt;
   }
 
@@ -52,15 +52,15 @@ contract MockOracle is Oracle {
     nonceToRequestId[_nonce] = _requestId;
   }
 
-  function mock_setRequestCreatedAt(bytes32 _requestId, uint128 _requestCreatedAt) external {
+  function mock_setRequestCreatedAt(bytes32 _requestId, uint256 _requestCreatedAt) external {
     requestCreatedAt[_requestId] = _requestCreatedAt;
   }
 
-  function mock_setResponseCreatedAt(bytes32 _responseId, uint128 _responseCreatedAt) external {
+  function mock_setResponseCreatedAt(bytes32 _responseId, uint256 _responseCreatedAt) external {
     responseCreatedAt[_responseId] = _responseCreatedAt;
   }
 
-  function mock_setDisputeCreatedAt(bytes32 _disputeId, uint128 _disputeCreatedAt) external {
+  function mock_setDisputeCreatedAt(bytes32 _disputeId, uint256 _disputeCreatedAt) external {
     disputeCreatedAt[_disputeId] = _disputeCreatedAt;
   }
 

--- a/solidity/test/unit/Oracle.t.sol
+++ b/solidity/test/unit/Oracle.t.sol
@@ -414,7 +414,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     // Set the request creation time
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
 
     // Mock and expect the responseModule propose call:
     _mockAndExpect(
@@ -468,7 +468,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
   function test_proposeResponse_revertsIfInvalidCaller(address _caller) public {
     vm.assume(_caller != proposer && _caller != address(disputeModule));
 
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
 
     // Check: revert?
     vm.expectRevert(IOracle.Oracle_InvalidProposer.selector);
@@ -483,7 +483,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
    */
   function test_proposeResponse_revertsIfDuplicateResponse() public {
     // Set the request creation time
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
 
     // Test: propose a response
     vm.prank(proposer);
@@ -506,7 +506,7 @@ contract Oracle_Unit_ProposeResponse is BaseTest {
     // Set the finalization time
     bytes32 _requestId = _getId(mockRequest);
     oracle.mock_setFinalizedAt(_requestId, _finalizedAt);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
 
     // Check: Reverts if already finalized?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, (_requestId)));
@@ -525,7 +525,7 @@ contract Oracle_Unit_DisputeResponse is BaseTest {
     _responseId = _getId(mockResponse);
     _disputeId = _getId(mockDispute);
 
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
   }
 
   /**
@@ -563,7 +563,7 @@ contract Oracle_Unit_DisputeResponse is BaseTest {
    */
   function test_disputeResponse_revertIfProposerIsNotValid(address _otherProposer) public {
     vm.assume(_otherProposer != proposer);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
 
     // Check: revert?
     vm.expectRevert(IOracle.Oracle_InvalidProposer.selector);
@@ -624,7 +624,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
    */
   function test_updateDisputeStatus() public {
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), block.timestamp);
 
     // Try every initial status
     for (uint256 _previousStatus; _previousStatus < uint256(type(IOracle.DisputeStatus).max); _previousStatus++) {
@@ -669,7 +669,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
 
     // Setting a random dispute id, not matching the mockDispute
     oracle.mock_setDisputeOf(_getId(mockResponse), _randomId);
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _disputeId));
@@ -691,7 +691,7 @@ contract Oracle_Unit_UpdateDisputeStatus is BaseTest {
 
     // Mock the dispute
     oracle.mock_setDisputeOf(_responseId, _disputeId);
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_NotDisputeOrResolutionModule.selector, proposer));
@@ -725,9 +725,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
   function test_resolveDispute_callsResolutionModule() public {
     // Mock the dispute
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
@@ -751,7 +751,7 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
    * @notice Test the revert when the function is called with an non-existent dispute id
    */
   function test_resolveDispute_revertsIfInvalidDisputeId() public {
-    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), uint128(block.timestamp));
+    oracle.mock_setDisputeCreatedAt(_getId(mockDispute), block.timestamp);
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _getId(mockDispute)));
@@ -788,9 +788,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
 
       // Mock the dispute
       oracle.mock_setDisputeOf(_responseId, _disputeId);
-      oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-      oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
-      oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+      oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+      oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
+      oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
       oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus(_status));
 
       // Check: revert?
@@ -819,9 +819,9 @@ contract Oracle_Unit_ResolveDispute is BaseTest {
     // Mock the dispute
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Escalated);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     // Check: revert?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_NoResolutionModule.selector, _disputeId));
@@ -903,8 +903,8 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
 
     // Mock the finalize call on all modules
     bytes memory _calldata = abi.encodeCall(IModule.finalizeRequest, (mockRequest, mockResponse, _caller));
@@ -945,7 +945,7 @@ contract Oracle_Unit_Finalize is BaseTest {
    */
   function test_finalize_revertsIfInvalidResponse() public {
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
     oracle.mock_setResponseCreatedAt(_requestId, 0);
 
     // Check: revert?
@@ -964,10 +964,10 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _responseId = _getId(mockResponse);
 
     // Test: finalize a finalized request
-    oracle.mock_setFinalizedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setFinalizedAt(_requestId, block.timestamp);
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
 
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, _requestId));
     vm.prank(requester);
@@ -985,8 +985,8 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Store the response
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_requestId, block.timestamp);
 
     // Test: finalize the request
     vm.expectRevert(ValidatorLib.ValidatorLib_InvalidResponseBody.selector);
@@ -1008,8 +1008,8 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Submit a response to the request
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
     oracle.mock_setDisputeOf(_responseId, _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Won);
 
@@ -1032,7 +1032,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     vm.assume(_caller != address(0));
 
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
     mockResponse.requestId = bytes32(0);
 
     // Create mock request and store it
@@ -1074,7 +1074,7 @@ contract Oracle_Unit_Finalize is BaseTest {
     vm.assume(_status <= uint256(type(IOracle.DisputeStatus).max));
 
     bytes32 _requestId = _getId(mockRequest);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
 
     IOracle.DisputeStatus _disputeStatus = IOracle.DisputeStatus(_status);
 
@@ -1111,8 +1111,8 @@ contract Oracle_Unit_Finalize is BaseTest {
     bytes32 _requestId = _getId(mockRequest);
 
     // Override the finalizedAt to make it be finalized
-    oracle.mock_setFinalizedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setFinalizedAt(_requestId, block.timestamp);
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
 
     // Test: finalize a finalized request
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, _requestId));
@@ -1130,7 +1130,7 @@ contract Oracle_Unit_Finalize is BaseTest {
 
     // Submit a response to the request
     oracle.mock_addResponseId(_requestId, _responseId);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
 
     // Check: reverts?
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_FinalizableResponseExists.selector, _responseId));
@@ -1150,9 +1150,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     // Mock and expect the dispute module call
     _mockAndExpect(
@@ -1196,9 +1196,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
     oracle.mock_setDisputeStatus(_disputeId, IOracle.DisputeStatus.Active);
-    oracle.mock_setRequestCreatedAt(_requestId, uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_responseId, uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_requestId, block.timestamp);
+    oracle.mock_setResponseCreatedAt(_responseId, block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
 
     // Mock and expect the dispute module call
     _mockAndExpect(
@@ -1224,8 +1224,8 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
    */
   function test_escalateDispute_revertsIfInvalidDispute() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), block.timestamp);
     oracle.mock_setDisputeCreatedAt(_disputeId, 0);
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDispute.selector));
 
@@ -1237,9 +1237,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
    */
   function test_escalateDispute_revertsIfDisputeNotValid() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_InvalidDisputeId.selector, _disputeId));
 
     // Test: escalate the dispute
@@ -1248,9 +1248,9 @@ contract Oracle_Unit_EscalateDispute is BaseTest {
 
   function test_escalateDispute_revertsIfDisputeNotActive() public {
     bytes32 _disputeId = _getId(mockDispute);
-    oracle.mock_setRequestCreatedAt(_getId(mockRequest), uint128(block.timestamp));
-    oracle.mock_setResponseCreatedAt(_getId(mockResponse), uint128(block.timestamp));
-    oracle.mock_setDisputeCreatedAt(_disputeId, uint128(block.timestamp));
+    oracle.mock_setRequestCreatedAt(_getId(mockRequest), block.timestamp);
+    oracle.mock_setResponseCreatedAt(_getId(mockResponse), block.timestamp);
+    oracle.mock_setDisputeCreatedAt(_disputeId, block.timestamp);
     oracle.mock_setDisputeOf(_getId(mockResponse), _disputeId);
 
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_CannotEscalate.selector, _disputeId));


### PR DESCRIPTION
# 🤖 Linear

We probably need to update events as well.

Closes OPO-647
